### PR TITLE
Fixes Forge Microblocks ID conflict

### DIFF
--- a/data/.minecraft/config/chisel.cfg
+++ b/data/.minecraft/config/chisel.cfg
@@ -96,7 +96,7 @@ features {
     B:dirt=true
     B:emeraldBlock=true
     B:endStone=true
-    B:factory=true
+    B:factory=false
     B:fantasy=true
     B:futura=true
     B:glass=true
@@ -167,7 +167,7 @@ features {
     B:tyrian=true
     B:uranium=true
     B:valentines=true
-    B:voidstone=true
+    B:voidstone=false
     B:voidstonePillars=true
     B:warningSign=true
     B:waterstone=true


### PR DESCRIPTION
The Chisel mod tries to register several blocks with the same name under
different IDs.  The two that are in conflict are Voidstone and Factory
blocks.  These are purely aesthetic and are only used for decoration in
the Chisel mod, and therefore disabling them to allow Forge Microblocks
to work isn't a problem.