### PR TITLE
Fixes Railcraft steam block error

### DIFF
--- a/data/.minecraft/config/railcraft/blocks.cfg
+++ b/data/.minecraft/config/railcraft/blocks.cfg
@@ -23,7 +23,7 @@ blocks {
     B:elevator=true
     B:firestone.recharge=true
     B:fluid.creosote=true
-    B:fluid.steam=true
+    B:fluid.steam=false
     B:frame=true
     B:glass=true
     B:lamp=true


### PR DESCRIPTION
Disables the railcraft steam block because Thermal Foundation already
has the steam block registered.  Tested:  All Railcraft steam machines
function normally with this block disabled.