### PR TITLE
Disable Morph mob abilities

### DIFF
--- a/data/.minecraft/config/Morph.cfg
+++ b/data/.minecraft/config/Morph.cfg
@@ -11,7 +11,7 @@ abilities {
     # 
     # Min: 0
     # Max: 1
-    I:abilities=1
+    I:abilities=0
 
     # Change the requirement of killing a wither to a custom mob instead
     # Use the full class name of the mob to make Morph bind to the killing of that mob type.(Eg: am2.entities.EntityBattleChicken)


### PR DESCRIPTION
Morph allows you to transform into whatever mobs you kill.  Moreover it
allows you to use their abilities such as flight and wither.  This
disables those abilities.  Tested in single player survival.